### PR TITLE
Make ember-power-select sass-optional when consuming app that uses sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Node `addChild` model function to create public child elements
+- Import compiled css for ember-power-select even when consumin app uses SASS
+    - This can be overriden by setting ember-power-select.useSass to true in the app's options
 
 ### Removed
 - ember-data-has-many-query

--- a/index.js
+++ b/index.js
@@ -101,6 +101,18 @@ module.exports = {
                 useScss: true
             };
         }
+
+        // Set options.ember-power-select.useSass to true in consuming app to use SASS styles
+        // from ember-power-select (must import manually with @import 'ember-power-select').
+        if (!(app.options['ember-power-select'] && app.options['ember-power-select'].useSass)) {
+            // ember-power-select normally skips inclusion of the precompiled css file if
+            // the consuming app uses SASS, but using @import 'ember-power-select' in ember-osf
+            // doesn't work properly, so we just import the compiled css.
+            if (!!app.registry.availablePlugins['ember-cli-sass']) {
+                app.import('vendor/ember-power-select.css');
+            }
+        }
+
         return app;
     },
     treeForAddon: function(tree) {

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = {
             // ember-power-select normally skips inclusion of the precompiled css file if
             // the consuming app uses SASS, but using @import 'ember-power-select' in ember-osf
             // doesn't work properly, so we just import the compiled css.
-            if (!!app.registry.availablePlugins['ember-cli-sass']) {
+            if (app.registry.availablePlugins['ember-cli-sass']) {
                 app.import('vendor/ember-power-select.css');
             }
         }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Makes use of ember-power-select SASS styles optional when consuming app uses SASS.

## Summary of Changes

Added code to index.js to import compiled ember-power-select.css unless ember-power-select.useSass is set to true in the consuming app's options.

## Side Effects / Testing Notes

ember-power-select "just works" in most cases

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
